### PR TITLE
Chore - possibility to inject URLSession to be used by ChatClient

### DIFF
--- a/Sources/StreamChat/ChatClient.swift
+++ b/Sources/StreamChat/ChatClient.swift
@@ -243,7 +243,7 @@ public class ChatClient {
     /// The default configuration of URLSession to be used for both the `APIClient` and `WebSocketClient`. It contains all
     /// required header auth parameters to make a successful request.
     private var urlSessionConfiguration: URLSessionConfiguration {
-        let configuration = URLSessionConfiguration.default
+        let configuration = config.urlSessionConfiguration
         configuration.waitsForConnectivity = false
         configuration.httpAdditionalHeaders = sessionHeaders
         configuration.timeoutIntervalForRequest = config.timeoutIntervalForRequest

--- a/Sources/StreamChat/Config/ChatClientConfig.swift
+++ b/Sources/StreamChat/Config/ChatClientConfig.swift
@@ -186,9 +186,17 @@ public struct ChatClientConfig {
     /// whenever a new channel is created,/updated the SDK will try to
     /// match the channel list filter automatically.
     public var isChannelAutomaticFilteringEnabled: Bool = true
+    
+    /// The `URLSessionConfiguration` being used as default configuration for the `APIClient` and
+    /// `WebSocketClient`
+    public let urlSessionConfiguration: URLSessionConfiguration
 
-    public init(apiKey: APIKey) {
+    public init(
+        apiKey: APIKey,
+        urlSessionConfiguration: URLSessionConfiguration = .default
+    ) {
         self.apiKey = apiKey
+        self.urlSessionConfiguration = urlSessionConfiguration
         isClientInActiveMode = !Bundle.main.isAppExtension
     }
 }

--- a/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
+++ b/Tests/StreamChatTests/StreamChat/ChatClient_Tests.swift
@@ -328,6 +328,23 @@ final class ChatClient_Tests: XCTestCase {
         XCTAssertEqual(client.activeChannelControllers.count, 0)
         XCTAssertEqual(client.activeChannelListControllers.count, 0)
     }
+    
+    
+    func test_apiClient_usesInjectedURLSessionConfiguration() {
+        // configure a URLSessionConfiguration with a URLProtocol class
+        var urlSessionConfiguration = URLSessionConfiguration.default
+        URLProtocol_Mock.startTestSession(with: &urlSessionConfiguration)
+        
+        // initialise a ChatClient with a custom URLSessionConfiguration,
+        // which is used instead of `URLSessionConfiguration.default`
+        let chatClient = ChatClient(
+            config: .init(urlSessionConfiguration: urlSessionConfiguration))
+        
+        // make sure the `apiClient` is initialised using the injected
+        // `URLSessionConfiguration`
+        XCTAssertTrue(chatClient.apiClient.session.configuration.protocolClasses?
+            .contains(where: { $0 is URLProtocol_Mock.Type }) ?? false)
+    }
 
     // MARK: - Background workers tests
 
@@ -970,7 +987,12 @@ private struct Queue<Element> {
 }
 
 private extension ChatClientConfig {
-    init() {
-        self = .init(apiKey: APIKey(.unique))
+    init(
+        urlSessionConfiguration: URLSessionConfiguration = .default
+    ) {
+        self = .init(
+            apiKey: APIKey(.unique),
+            urlSessionConfiguration: urlSessionConfiguration
+        )
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Customer Support Ticket #39734

### 🎯 Goal

We, at Viz.ai, are heavily using `URLProtocol` based mocks for testing our application flows in our UI tests. While transitioning to Stream Chat we found that currently there's no way of injecting a prepared `URLSessionConfiguration` into the `ChatClient` to be used with our mocking engine. This pull request contains a proposal of how we could optionally inject such a prepared `URLSessionConfiguration` and unblock our development of UI tests.

### 📝 Summary
- Added a non-mutable `urlSessionConfiguration` property to the `ChatClientConfig` struct
- By default, `urlSessionConfiguration` will be initialised with `URLSessionConfiguration.default`, as before
- In `ChatClient`, `ChatClientConfig.urlSessionConfiguration` will be used instead of `URLSessionConfiguration.default`
- Added unit test to make sure that new configuration is used

### 🛠 Implementation

The goal was to change as little code as possible while making it obvious from an API perspective.

### 🎨 Showcase

not applicable - no visual changes

### 🧪 Manual Testing Notes

not applicable - default behaviour has not changed

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

_Provide a funny gif or image that relates to your work on this pull request. (Optional)_
